### PR TITLE
Feature(Bungee): Use server name as prefix for worlds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	compileOnly 'org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT'
+	compileOnly 'org.spigotmc:spigot-api:1.19-R0.1-SNAPSHOT'
 }
 
 processResources {

--- a/src/main/java/pl/kosma/worldnamepacket/SpigotPlugin.java
+++ b/src/main/java/pl/kosma/worldnamepacket/SpigotPlugin.java
@@ -1,5 +1,9 @@
 package pl.kosma.worldnamepacket;
 
+import com.google.common.io.ByteStreams;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+
 import java.nio.ByteBuffer;
 
 import org.bukkit.Bukkit;
@@ -12,12 +16,23 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 
 public class SpigotPlugin extends JavaPlugin implements Listener, PluginMessageListener {
+
+	private Boolean usingBungee;
+	private String bungeeServerName;
+
 	@Override
 	public void onEnable() {
 		this.getServer().getPluginManager().registerEvents(this, this);
 		this.getServer().getMessenger().registerIncomingPluginChannel(this, WorldNamePacket.CHANNEL_NAME_VOXELMAP, this);
 		this.getServer().getMessenger().registerOutgoingPluginChannel(this, WorldNamePacket.CHANNEL_NAME_VOXELMAP);
 		this.getServer().getMessenger().registerOutgoingPluginChannel(this, WorldNamePacket.CHANNEL_NAME_XAEROMAP);
+
+		this.usingBungee = this.getServer().spigot().getConfig().getBoolean("settings.bungeecord", false);
+		if (this.usingBungee) {
+			this.getServer().getMessenger().registerOutgoingPluginChannel(this, WorldNamePacket.CHANNEL_NAME_BUNGEECORD);
+			this.getServer().getMessenger().registerIncomingPluginChannel(this, WorldNamePacket.CHANNEL_NAME_BUNGEECORD, this);
+			this.getLogger().info("BungeeCord mode enabled, prefixing world-names with server-name");
+		}
 	}
 
 	@Override
@@ -25,9 +40,17 @@ public class SpigotPlugin extends JavaPlugin implements Listener, PluginMessageL
 		this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
 		this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
 	}
-	
+
 	private void sendWorldName(Player player, String channel) {
-		String worldNameString = player.getWorld().getName();
+		String worldNameString;
+
+		if (this.usingBungee) {
+			String tmpName = (this.bungeeServerName != null) ? this.bungeeServerName : "UNKNOWN";
+			worldNameString = tmpName + "_" + player.getWorld().getName();
+		} else {
+			worldNameString = player.getWorld().getName();
+		}
+
 		byte[] worldNameBytes = worldNameString.getBytes();
 		this.getLogger().info("WorldNamePacket: ["+channel+"] sending levelName: " + worldNameString);
 		ByteBuffer buffer = ByteBuffer.allocate(2+worldNameBytes.length)
@@ -44,19 +67,43 @@ public class SpigotPlugin extends JavaPlugin implements Listener, PluginMessageL
 	public void onPluginMessageReceived(String channel, Player player, byte[] bytes) {
 		if (channel.contentEquals(WorldNamePacket.CHANNEL_NAME_VOXELMAP)) {
 			sendWorldName(player, channel);
+		} else if (channel.contentEquals(WorldNamePacket.CHANNEL_NAME_BUNGEECORD)) {
+			ByteArrayDataInput input = ByteStreams.newDataInput(bytes);
+			String subchannel = input.readUTF();
+
+			if (subchannel.contentEquals("GetServer")) {
+				this.bungeeServerName = input.readUTF();
+				// update now that we know our server-name
+				for (Player p : this.getServer().getOnlinePlayers()) {
+					sendWorldName(p, WorldNamePacket.CHANNEL_NAME_XAEROMAP);
+				}
+			}
 		}
 	}
-	
+
 	/**
-	 * Xaero's Map handler (sent on every world/level change). 
+	 * Xaero's Map handler (sent on every world/level change).
 	 */
 	@EventHandler
 	public void onPlayerJoin(PlayerJoinEvent event) {
-		// Typical issue: the event is fired a bit too early and Xaero Map doesn't catch it.
-		// To make things simple, just delay sending until the next tick. It works. Hopefully.
+		// if we dont know our bungee server-name, ask for it
+		if (this.usingBungee && this.bungeeServerName == null) {
+			ByteArrayDataOutput out = ByteStreams.newDataOutput();
+			out.writeUTF("GetServer");
+			this.getServer().sendPluginMessage(this, WorldNamePacket.CHANNEL_NAME_BUNGEECORD, out.toByteArray());
+		}
+
+		// Typical issue: the event is fired a bit too early and Xaero Map doesn't catch
+		// it.
+		// To make things simple, just delay sending until the next tick. It works.
+		// Hopefully.
 		Bukkit.getScheduler().runTask(this, () -> {
 			sendWorldName(event.getPlayer(), WorldNamePacket.CHANNEL_NAME_XAEROMAP);
 		});
+		// re-send after ~5seconds to try mitigate slow loading
+		Bukkit.getScheduler().runTaskLater(this, () -> {
+			sendWorldName(event.getPlayer(), WorldNamePacket.CHANNEL_NAME_XAEROMAP);
+		}, 100L);
 	}
 
 	@EventHandler

--- a/src/main/java/pl/kosma/worldnamepacket/SpigotPlugin.java
+++ b/src/main/java/pl/kosma/worldnamepacket/SpigotPlugin.java
@@ -52,7 +52,7 @@ public class SpigotPlugin extends JavaPlugin implements Listener, PluginMessageL
 		}
 
 		byte[] worldNameBytes = worldNameString.getBytes();
-		this.getLogger().info("WorldNamePacket: ["+channel+"] sending levelName: " + worldNameString);
+		this.getLogger().info("["+channel+"] sending levelName: " + worldNameString);
 		ByteBuffer buffer = ByteBuffer.allocate(2+worldNameBytes.length)
 				                      .put(WorldNamePacket.PACKET_ID)
 				                      .put((byte) worldNameBytes.length)

--- a/src/main/java/pl/kosma/worldnamepacket/WorldNamePacket.java
+++ b/src/main/java/pl/kosma/worldnamepacket/WorldNamePacket.java
@@ -3,5 +3,6 @@ package pl.kosma.worldnamepacket;
 public class WorldNamePacket {
     public static final byte PACKET_ID = 0;
     public static final String CHANNEL_NAME_VOXELMAP = "worldinfo:world_id";
-    public static final String CHANNEL_NAME_XAEROMAP = "xaeroworldmap:main";			
+    public static final String CHANNEL_NAME_XAEROMAP = "xaeroworldmap:main";
+    public static final String CHANNEL_NAME_BUNGEECORD = "BungeeCord";
 }


### PR DESCRIPTION
Hey,

Great plugin! Very useful.
I made one addition, use/mod it if you are interested.

**What is the problem?**
For Bungeecord-servers, as noted in README, many worlds are mixed up due to same name.
However, the server-names in Bungeecord are unique.

**What is the solution?**
Prefix all world-names with the Bungeecord-server-name.

**Example**
Instead of "world", the name will be "server512_world". And it wont collide with "lobby_world" anymore.

**Known bugs?**
The first player joining will get "UNKNOWN_world" as mapname, but after a few seconds (at most) the bungeecord-server will reply with the server-name, and the worldname will be re-sent. So the name will be corrected. Possibly resulting in lots of new map entries in Xaero/client.

The server-name is saved after lookup, so only one player will have this problem ✨